### PR TITLE
Certificate chain depth fix REST consumer for broker 9.8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,7 +2,7 @@ name: build
 
 # Controls when the action will run. 
 on:
-  pull_request:
+  #pull_request:
 
   push:
 

--- a/README.md
+++ b/README.md
@@ -277,8 +277,6 @@ Step 1: For each public resource integration, [set up a public resource integrat
 
 ### Deployment Step Details
 
-> **Important:** AWS is currently using a server certificate with certificate chain depth larger than 3. The default PubSub+ [broker settings for accepted certificate chain depth for REST consumers of the message-vpn used](https://docs.solace.com/Solace-CLI/CLI-Reference/VMR_CLI_Commands.html#Root_enable_configure_message-vpn_rest_ssl_server-certificate-validation_max-certificate-chain-depth) is 3. It must be ensured that this setting is updated to at least 4 through the [CLI](https://docs.solace.com/Solace-CLI/Using-Solace-CLI.htm), [SEMP API](https://docs.solace.com/SEMP/Using-SEMP.htm) or [PubSub+ Broker Manager](https://docs.solace.com/Solace-PubSub-Manager/PubSub-Manager-Overview.htm). The [`setup-rdp.sh` script in this quick start](#step-4-configure-the-broker) includes a step to take care of this.
-
 #### Setting up a private integration base with an existing event broker
 
 * Use the `private_proxy_base.template`.
@@ -521,7 +519,9 @@ Once the message has been published to the queue, let's check the target S3 buck
 
 ## Troubleshooting Hints
 
-* First ensure that the API Gateway has been setup properly and can reach the target resource internally. Use the AWS "API Gateway" Service console and navigate to the method to be checked, then confirm proper data flow using the "TEST" feature.
+* AWS is currently using a server certificate with certificate chain depth larger than 3. The default PubSub+ [broker settings for accepted certificate chain depth for REST consumers of the message-vpn used](https://docs.solace.com/Solace-CLI/CLI-Reference/VMR_CLI_Commands.html#Root_enable_configure_message-vpn_rest_ssl_server-certificate-validation_max-certificate-chain-depth) is 3. It must be ensured that this setting is updated to at least 4 through the [CLI](https://docs.solace.com/Solace-CLI/Using-Solace-CLI.htm), [SEMP API](https://docs.solace.com/SEMP/Using-SEMP.htm) or [PubSub+ Broker Manager](https://docs.solace.com/Solace-PubSub-Manager/PubSub-Manager-Overview.htm). The [`setup-rdp.sh` script in this quick start](#step-4-configure-the-broker) includes a step to take care of this.
+
+* As part of investigating connectivity issues, ensure that the API Gateway has been setup properly and can reach the target resource internally. Use the AWS "API Gateway" Service console and navigate to the method to be checked, then confirm proper data flow using the "TEST" feature.
 
 ![API Gateway Testing](images/DebugAPI.png)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # PubSub+ and AWS Services Integration
 
-This project provides a simple, secure no-code integration of [AWS services](https://aws.amazon.com ) including [SNS](https://aws.amazon.com/sns ), [SQS](https://aws.amazon.com/sqs ), [Lambda](https://aws.amazon.com/lambda ) and [S3](https://aws.amazon.com/s3 ) into the [Solace PubSub+ Event Mesh](https://solace.com/use-cases/event-mesh ), so AWS services become seamless event mesh consumers and producers.
+This project is a best practice template intended for development and demo purposes. The tested and recommended Solace PubSub+ Software Event Broker version is 9.8.
+
+This document provides a simple, secure no-code integration of [AWS services](https://aws.amazon.com ) including [SNS](https://aws.amazon.com/sns ), [SQS](https://aws.amazon.com/sqs ), [Lambda](https://aws.amazon.com/lambda ) and [S3](https://aws.amazon.com/s3 ) into the [Solace PubSub+ Event Mesh](https://solace.com/use-cases/event-mesh ), so AWS services become seamless event mesh consumers and producers.
 
 Contents:
 
@@ -274,6 +276,8 @@ The following step creates a service integration with an existing PubSub+ Event 
 Step 1: For each public resource integration, [set up a public resource integration](#setting-up-a-public-resource-integration).
 
 ### Deployment Step Details
+
+**Important:** AWS is currently using a server certificate with certificate chain depth larger than 3. The default PubSub+ [broker settings for accepted certificate chain depth for REST Delivery Points of the message-vpn used](https://docs.solace.com/Solace-CLI/CLI-Reference/VMR_CLI_Commands.html#Root_enable_configure_message-vpn_rest_ssl_server-certificate-validation_max-certificate-chain-depth) is 3. It must be ensured that this setting is updated to at least 4 through the [CLI](https://docs.solace.com/Solace-CLI/Using-Solace-CLI.htm), [SEMP API](https://docs.solace.com/SEMP/Using-SEMP.htm) or [PubSub+ Broker Manager](https://docs.solace.com/Solace-PubSub-Manager/PubSub-Manager-Overview.htm). The [`setup-rdp.sh` script in this quick start](#step-4-configure-the-broker) includes a step to take care of this.
 
 #### Setting up a private integration base with an existing event broker
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Step 1: For each public resource integration, [set up a public resource integrat
 
 ### Deployment Step Details
 
-**Important:** AWS is currently using a server certificate with certificate chain depth larger than 3. The default PubSub+ [broker settings for accepted certificate chain depth for REST Delivery Points of the message-vpn used](https://docs.solace.com/Solace-CLI/CLI-Reference/VMR_CLI_Commands.html#Root_enable_configure_message-vpn_rest_ssl_server-certificate-validation_max-certificate-chain-depth) is 3. It must be ensured that this setting is updated to at least 4 through the [CLI](https://docs.solace.com/Solace-CLI/Using-Solace-CLI.htm), [SEMP API](https://docs.solace.com/SEMP/Using-SEMP.htm) or [PubSub+ Broker Manager](https://docs.solace.com/Solace-PubSub-Manager/PubSub-Manager-Overview.htm). The [`setup-rdp.sh` script in this quick start](#step-4-configure-the-broker) includes a step to take care of this.
+> **Important:** AWS is currently using a server certificate with certificate chain depth larger than 3. The default PubSub+ [broker settings for accepted certificate chain depth for REST consumers of the message-vpn used](https://docs.solace.com/Solace-CLI/CLI-Reference/VMR_CLI_Commands.html#Root_enable_configure_message-vpn_rest_ssl_server-certificate-validation_max-certificate-chain-depth) is 3. It must be ensured that this setting is updated to at least 4 through the [CLI](https://docs.solace.com/Solace-CLI/Using-Solace-CLI.htm), [SEMP API](https://docs.solace.com/SEMP/Using-SEMP.htm) or [PubSub+ Broker Manager](https://docs.solace.com/Solace-PubSub-Manager/PubSub-Manager-Overview.htm). The [`setup-rdp.sh` script in this quick start](#step-4-configure-the-broker) includes a step to take care of this.
 
 #### Setting up a private integration base with an existing event broker
 
@@ -476,7 +476,7 @@ Select S3 as the resource, and provide the S3 resource ARN and the VPC Id from [
 
 The output of the template will provide the REST API URL that can be used to send data to the S3 resource.
 
-![Sample Base](images/SampleBase.png)
+![Sample Base](images/SamplePrivIntegration.png)
 
 #### Step 4: Configure the broker
 

--- a/scripts/setup-rdp.sh
+++ b/scripts/setup-rdp.sh
@@ -155,21 +155,14 @@ function semp_query {
 }
 ##
 #
-# Setting up aws trusted root
-echo "`date` INFO: Setting up aws trusted root (may report fail if already setup)"
+# Fixing message VPN certificate depth
+echo "`date` INFO: Fixing message VPN certificate depth"
 online_results=$(semp_query ${ADMIN_USERNAME} ${ADMIN_PASSWORD} ${BROKER_SEMP_URL}/SEMP \
-    "<rpc><authentication><create><certificate-authority><ca-name>aws</ca-name></certificate-authority></create></authentication></rpc>" \
+    "<?xml version="1.0"?>
+<rpc><message-vpn><vpn-name>${BROKER_MESSAGE_VPN}</vpn-name><rest><ssl><server-certificate-validation><max-certificate-chain-depth><max-depth>4</max-depth></max-certificate-chain-depth></server-certificate-validation></ssl></rest></message-vpn></rpc>" \
     "/rpc-reply/execute-result/@code")
-ca_created=`echo ${online_results} | xmllint -xpath "string(returnInfo/valueSearchResult)" -`
-echo "`date` INFO: certificate-authority created status: ${ca_created}" 
-
-wget -q -O ./AmazonRootCA1.pem -nv https://www.amazontrust.com/repository/AmazonRootCA1.pem
-online_results=$(semp_query ${ADMIN_USERNAME} ${ADMIN_PASSWORD} ${BROKER_SEMP_URL}/SEMP \
-    "<rpc><authentication><certificate-authority><ca-name>aws</ca-name><certificate><raw-data>`awk '{printf \"%s\\n\", $0}' AmazonRootCA1.pem`</raw-data></certificate></certificate-authority></authentication></rpc>" \
-    "/rpc-reply/execute-result/@code")
-ca_loaded=`echo ${online_results} | xmllint -xpath "string(returnInfo/valueSearchResult)" -`
-echo "`date` INFO: certificate-authority file loaded status: ${ca_loaded}"
-rm -f ./AmazonRootCA1.pem
+ca_depth_fixed=`echo ${online_results} | xmllint -xpath "string(returnInfo/valueSearchResult)" -`
+echo "`date` INFO: certificate-authority max-certificate-chain-depth fixed status: ${ca_depth_fixed}" 
 #
 # Setting up PubSub+ Queue
 echo "`date` INFO: Setting up PubSub+ Queue"

--- a/scripts/setup-rdp.sh
+++ b/scripts/setup-rdp.sh
@@ -106,61 +106,14 @@ echo
 IFS='/' read -r protocol empty baseUrl apiStage apiPath <<< "$INTEGRATION_API_URL"
 IFS='.' read -r gwId apiRegionUrl <<< "$baseUrl"
 #
-## Functions
-function semp_query {
-  # Variables:
-  count_search=""
-  name=$1
-  password=$2
-  url=$3
-  query=$4
-  value_search=$5
-  script_name="semp_query"
-  verbose=0
-
-  if [[ ${url} = "" || ${name} = "" || ${password} = "" || ${query} = "" ]]; then
-    echo "`date` ERROR: url, name, password and query are madatory fields" >&2
-    echo  '<returnInfo><errorInfo>missing parameter</errorInfo></returnInfo>'
-    exit 1
-  fi
-  if [ `curl --write-out '%{http_code}' --silent --output /dev/null -u ${name}:${password} ${url} -d "<rpc><show><version/></show></rpc>"` != "200" ] ; then
-    echo  "<returnInfo><errorInfo>management host is not responding</errorInfo></returnInfo>"
-    exit 1
-  fi
-  query_response=`curl -sS -u ${name}:${password} ${url} -d "${query}"`
-  # Validate first char of response is "<", otherwise no hope of being valid xml
-  if [[ ${query_response:0:1} != "<" ]] ; then
-    echo  "<returnInfo><errorInfo>no valid xml returned</errorInfo></returnInfo>"
-    exit 1
-  fi
-  query_response_code=`echo $query_response | xmllint -xpath 'string(/rpc-reply/execute-result/@code)' -`
-
-  if [[ -z ${query_response_code} && ${query_response_code} != "ok" ]]; then
-      echo  "<returnInfo><errorInfo>query failed -${query_response_code}-</errorInfo></returnInfo>"
-      exit 1
-  fi
-  #echo "`date` INFO: query passed ${query_response_code}" >&2
-  if [[ ! -z $value_search ]]; then
-      value_result=`echo $query_response | xmllint -xpath "string($value_search)" -`
-      echo  "<returnInfo><errorInfo></errorInfo><valueSearchResult>${value_result}</valueSearchResult></returnInfo>"
-      exit 0
-  fi
-  if [[ ! -z $count_search ]]; then
-      count_line=`echo $query_response | xmllint -xpath "$count_search" -`
-      count_string=`echo $count_search | cut -d '"' -f 2`
-      count_result=`echo ${count_line} | tr "><" "\n" | grep -c ${count_string}`
-      echo  "<returnInfo><errorInfo></errorInfo><countSearchResult>${count_result}</countSearchResult></returnInfo>"
-      exit 0
-  fi
-}
-##
+## Config steps
 #
 # Fixing message VPN certificate depth
 echo "`date` INFO: Fixing message VPN certificate depth"
 curl --user ${ADMIN_USERNAME}:${ADMIN_PASSWORD} \
      --request PATCH \
      --header "content-type:application/json" \
-     --data "{\"msgVpnName\":\"${BROKER_MESSAGE_VPN}\",\"restTlsServerCertMaxChainDepth\":5}" \
+     --data "{\"msgVpnName\":\"${BROKER_MESSAGE_VPN}\",\"restTlsServerCertMaxChainDepth\":4}" \
      "${BROKER_SEMP_URL}/SEMP/v2/config/msgVpns/${BROKER_MESSAGE_VPN}"
 #
 # Setting up PubSub+ Queue

--- a/scripts/setup-rdp.sh
+++ b/scripts/setup-rdp.sh
@@ -157,12 +157,11 @@ function semp_query {
 #
 # Fixing message VPN certificate depth
 echo "`date` INFO: Fixing message VPN certificate depth"
-online_results=$(semp_query ${ADMIN_USERNAME} ${ADMIN_PASSWORD} ${BROKER_SEMP_URL}/SEMP \
-    "<?xml version="1.0"?>
-<rpc><message-vpn><vpn-name>${BROKER_MESSAGE_VPN}</vpn-name><rest><ssl><server-certificate-validation><max-certificate-chain-depth><max-depth>4</max-depth></max-certificate-chain-depth></server-certificate-validation></ssl></rest></message-vpn></rpc>" \
-    "/rpc-reply/execute-result/@code")
-ca_depth_fixed=`echo ${online_results} | xmllint -xpath "string(returnInfo/valueSearchResult)" -`
-echo "`date` INFO: certificate-authority max-certificate-chain-depth fixed status: ${ca_depth_fixed}" 
+curl --user ${ADMIN_USERNAME}:${ADMIN_PASSWORD} \
+     --request PATCH \
+     --header "content-type:application/json" \
+     --data "{\"msgVpnName\":\"${BROKER_MESSAGE_VPN}\",\"restTlsServerCertMaxChainDepth\":5}" \
+     "${BROKER_SEMP_URL}/SEMP/v2/config/msgVpns/${BROKER_MESSAGE_VPN}"
 #
 # Setting up PubSub+ Queue
 echo "`date` INFO: Setting up PubSub+ Queue"


### PR DESCRIPTION
* Added step to rdp create script to increase default certificate chain depth to accommodate AWS server certificates on broker 9.8
* Removed provisioning of AWS CA as no longer needed on broker 9.8